### PR TITLE
CLI con funcionalidad para recibir argumento stats y test al 96%

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,13 +1,23 @@
 const { mdLinks } = require('./index.js');
+const { statLinks, statAndValidateLinks } = require('./functions')
 
 const route = process.argv[2]
-const argv = process.argv;
-const validate = argv.includes('--validate');
+const opt = process.argv;
+const validate = opt.includes('--validate');
+const stats = opt.includes('--stats');
 
 
-mdLinks(route, validate)
+mdLinks(route, { validate })
   .then((res) => {
-    console.log(res);
+    if (validate && stats) {
+      console.log(statAndValidateLinks(res))
+    } else if (!validate && stats) {
+      console.log(statLinks(res));
+    } else if (validate && !stats) {
+      console.log(res);
+    } else if (!validate && !stats) {
+      console.log(res);
+    }
   })
   .catch((error) => {
     console.log(error);

--- a/functions.js
+++ b/functions.js
@@ -110,6 +110,25 @@ const validateLinks = (links) => {
   return Promise.all(linksValidated);
 };
 
+/*Funciones para trabajar con el argumento stats*/
+const statLinks = (arrLinks) => {
+  const uniqueLinks = new Set(arrLinks.map((link) => link.href)).size;
+  return {
+    Total: arrLinks.length,
+    Unique: uniqueLinks
+  }
+};
+
+const statAndValidateLinks = (arrLinks) => {
+  const uniqueLinks = new Set(arrLinks.map((link) => link.href)).size;
+  const brokenLinks = arrLinks.filter((link) => link.OK === 'Fail');
+  return {
+    Total: arrLinks.length,
+    Unique: uniqueLinks,
+    Broken: brokenLinks.length
+  } 
+};
+
 module.exports = {
   pathExist,
   getAbsolutePath,
@@ -118,4 +137,6 @@ module.exports = {
   isDirectory,
   getLinks,
   validateLinks,
+  statLinks,
+  statAndValidateLinks
 };

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const {
   validateLinks,
 } = require('./functions.js');
 
-const mdLinks = (path, options) =>
+const mdLinks = (path, options = {validate: false}) =>
   new Promise((resolve, reject) => {
     // variable que contendrá el arreglo de archivos md
     let files;
@@ -40,9 +40,9 @@ const mdLinks = (path, options) =>
                 `No se encontraron links en el archivo con ruta: ${pathAbsolute}`
               );
             } else {
-              if (options === false) {
+              if (options.validate === false) {
                 return resolve(links);
-              } else if (options === true) {
+              } else if (options.validate === true) {
                 Promise.all([validateLinks(links)]).then((res) => {
                   arrValidateLinks = res.flat();
                   resolve(arrValidateLinks);

--- a/test/functions.spec.js
+++ b/test/functions.spec.js
@@ -6,12 +6,42 @@ const {
   isFileMd,
   isDirectory,
   searchFilesMd,
-  validateLinks
+  validateLinks,
+  statLinks,
+  statAndValidateLinks
  } = require('../functions.js')
  const tryPathAbsolute = `${process.cwd()}`;
  const tryPathTest = [`${tryPathAbsolute}\\test\\pruebaTest.md`];
  const fetch = require('node-fetch');
  jest.mock('node-fetch');
+
+ const arrayLinksValidatedFailCatch = [
+  {
+    href: 'http://community.laboratoria.la/t/modulos-librerias-paquetes-frameworks-cual-es-la-diferencia/175',
+    text: 'Módulos, librerías, paquetes, frameworks... ¿cuál es la diferencia?',
+    file: `${tryPathAbsolute}\\CarpetaDePrueba\\Prueba\\README-mdlinks-para-prueba.md`,
+    OK: 'Fail',
+    status: 'fetch failed',
+    message: 'Error: getaddrinfo ENOTFOUND community.laboratoria.la'
+  }
+];
+
+const arrayLinksValidated = [
+  {
+    href: 'https://www.javascripttutorial.net/javascript-dom/javascript-innerhtml-vs-createelement/',
+    text: 'Diferencia entre createElement e innerHTML',
+    file: `${tryPathAbsolute}\\test\\pruebaTest.md`,
+    status: 200,
+    OK: 'OK'
+  },
+  {
+    href: 'https://www.todojs.com/tipos-datos-javascript-es6/',
+    text: 'Diferencia entre datos atómicos y estructurados',
+    file: `${tryPathAbsolute}\\test\\pruebaTest.md`,
+    status: 200,
+    OK: 'OK'
+  }
+];
  /* --------------------------------------------- testeo de functions -----------------------------------------------------*/
 
 describe('pathExist', () => {
@@ -73,22 +103,6 @@ describe('getLinks', () => {
 });
 describe('validateLinks', () => {
   it('Debería retornar un array de objetos con las propiedades de los links validados', async () => {
-    const arrayLinksValidated = [
-      {
-        href: 'https://www.javascripttutorial.net/javascript-dom/javascript-innerhtml-vs-createelement/',
-        text: 'Diferencia entre createElement e innerHTML',
-        file: `${tryPathAbsolute}\\test\\pruebaTest.md`,
-        status: 200,
-        OK: 'OK'
-      },
-      {
-        href: 'https://www.todojs.com/tipos-datos-javascript-es6/',
-        text: 'Diferencia entre datos atómicos y estructurados',
-        file: `${tryPathAbsolute}\\test\\pruebaTest.md`,
-        status: 200,
-        OK: 'OK'
-      }
-    ];
     fetch.mockImplementationOnce(() => 
     Promise.resolve({
       status: 200,
@@ -143,16 +157,6 @@ describe('validateLinks', () => {
     });
   });
   it('Debería retornar un array de objetos con las propiedades de los links validados', async () => {
-    const arrayLinksValidatedFailCatch = [
-      {
-        href: 'http://community.laboratoria.la/t/modulos-librerias-paquetes-frameworks-cual-es-la-diferencia/175',
-        text: 'Módulos, librerías, paquetes, frameworks... ¿cuál es la diferencia?',
-        file: `${tryPathAbsolute}\\CarpetaDePrueba\\Prueba\\README-mdlinks-para-prueba.md`,
-        OK: 'Fail',
-        status: 'fetch failed',
-        message: 'Error: getaddrinfo ENOTFOUND community.laboratoria.la'
-      }
-    ];
     fetch.mockImplementationOnce(() => 
     Promise.resolve({
       OK: 'Fail',
@@ -171,6 +175,25 @@ describe('validateLinks', () => {
           message: 'Error: getaddrinfo ENOTFOUND community.laboratoria.la'
         }
       ]);
+    });
+  });
+});
+describe('statLinks', () => {
+  it('Debería retornar un objeto con las propiedades Total: (numero de links totales) y Unique: (total de links unicos)', () => {
+    statLinks(arrayLinksValidated);
+    expect(statLinks(arrayLinksValidated)).toEqual({
+      Total: 2,
+      Unique: 2
+    });
+  });
+});
+describe('statAndValidateLinks', () => {
+  it('Debería retornar un objeto con propiedades de total de links, unicos y rotos(broken)', () => {
+    statAndValidateLinks(arrayLinksValidated);
+    expect(statAndValidateLinks(arrayLinksValidated)).toEqual({
+      Total: 2,
+      Unique: 2,
+      Broken: 0
     });
   });
 });

--- a/test/md-links.spec.js
+++ b/test/md-links.spec.js
@@ -10,13 +10,14 @@ const {
 const { mdLinks } = require('../index.js');
 const tryPathAbsolute = `${process.cwd()}`;
 const tryPathTest = [`${tryPathAbsolute}\\test\\pruebaTest.md`];
+let options = {validate: true};
 const fetch = require('node-fetch');
 jest.mock('node-fetch');
 
 describe('mdLinks', () => {
   it('Debería devolver una promesa', () => {
-    mdLinks('./test/pruebaTest.md', true).then(() => {
-      expect(mdLinks('./test/pruebaTest.md', true)).toBe(typeof Promise);
+    mdLinks('./test/pruebaTest.md', options).then(() => {
+      expect(mdLinks('./test/pruebaTest.md', options)).toBe(typeof Promise);
     });
   });
   it('Debería rechazar la promesa si el path no existe', () => {
@@ -27,8 +28,27 @@ describe('mdLinks', () => {
     mdLinks(`${tryPathAbsolute}\\test`);
     expect(pathExist(`${tryPathAbsolute}\\test`)).toEqual(true);
   });
+  it('Debería retornar un array con los links encontrados', () => {
+    mdLinks(`${tryPathAbsolute}\\test\\pruebaTest.md`, options = false).then( async () => {
+      const linksForTest = [
+        {
+          href: 'https://www.javascripttutorial.net/javascript-dom/javascript-innerhtml-vs-createelement/',
+          text: 'Diferencia entre createElement e innerHTML',
+          file: `${tryPathAbsolute}\\test\\pruebaTest.md`
+        },
+        {
+          href: 'https://www.todojs.com/tipos-datos-javascript-es6/',
+          text: 'Diferencia entre datos atómicos y estructurados',
+          file: `${tryPathAbsolute}\\test\\pruebaTest.md`
+        }
+      ];
+      return await getLinks([tryPathTest]).then((res) => {
+        expect(res).toEqual(linksForTest);
+      });
+    });
+  });
   it('Debería devolver una promesa', async () => {
-    mdLinks('./test/pruebaTest.md', true).then(async () => {
+    mdLinks('./test/pruebaTest.md', options = true).then(async () => {
       const arrayLinksValidated = [
         {
           href: 'https://www.javascripttutorial.net/javascript-dom/javascript-innerhtml-vs-createelement/',
@@ -69,7 +89,6 @@ describe('mdLinks', () => {
           }
         ]);
       });
-      expect(mdLinks('./test/pruebaTest.md', true)).toEqual();
     });
   });
   it('Debería rechazar la promesa si el path no es ni un directorio ni un archivo md', () => {


### PR DESCRIPTION
Se escribieron las funciones y sintaxis para poder ofrecer estadísticas de links totales, links únicos y links rotos contenidos en los archivos md que se leen por medio de mdLinks.